### PR TITLE
In order to prevent Error 349 in Chrome

### DIFF
--- a/application/controllers/file.php
+++ b/application/controllers/file.php
@@ -28,7 +28,7 @@ class File_Controller extends Base_Controller {
 
 		$headers = array(
 			'Content-Type'			=> 'application/octet-stream',
-			'Content-Disposition'	=> 'attachment; filename=' . $name,
+			'Content-Disposition'	=> 'attachment; filename="' . $name .'"',
 			'Content-Length'		=> filesize($file),
 			'Pragma'				=> 'no-cache',
 		);


### PR DESCRIPTION
Duplicate Headers Error 349 (net::ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION)
